### PR TITLE
Reduce Code ; Double deklared

### DIFF
--- a/utils.ino
+++ b/utils.ino
@@ -355,7 +355,7 @@ void setPinMapping(byte boardID)
   ign5_pin_mask = digitalPinToBitMask(pinCoil5);
 
   //And for inputs
-  pinMode(pinMAP, INPUT);
+  pinMode(pinMAP, INPUT_PULLUP);
   pinMode(pinO2, INPUT);
   pinMode(pinO2_2, INPUT);
   pinMode(pinTPS, INPUT);
@@ -371,9 +371,9 @@ void setPinMapping(byte boardID)
   else { pinMode(pinLaunch, INPUT); } //If Launch Pull Resistor is not set make input float.
 
   //Set default values
-  digitalWrite(pinMAP, HIGH);
+  //digitalWrite(pinMAP, HIGH);
   //digitalWrite(pinO2, LOW);
-  digitalWrite(pinTPS, LOW);
+  //digitalWrite(pinTPS, LOW);
 }
 
 /*


### PR DESCRIPTION
Hello,

i have see does the code is with ditigalWrite and pinMode is double deklared.
Because if u set for example 
pinMode(inMAP, INPUT) it will automaticly disable the PULL_UP Resistor

The library in arduino is Arduino/hardware/arduino/avr/cores/arduino/wiring_digital.c

The Code in this Library

```
void pinMode(uint8_t pin, uint8_t mode)
{
	uint8_t bit = digitalPinToBitMask(pin);
	uint8_t port = digitalPinToPort(pin);
	volatile uint8_t *reg, *out;

	if (port == NOT_A_PIN) return;

	// JWS: can I let the optimizer do this?
	reg = portModeRegister(port);
	out = portOutputRegister(port);

	if (mode == INPUT) { 
		uint8_t oldSREG = SREG;
                cli();
		*reg &= ~bit;
		*out &= ~bit;
		SREG = oldSREG;
	} else if (mode == INPUT_PULLUP) {
		uint8_t oldSREG = SREG;
                cli();
		*reg &= ~bit;
		*out |= bit;
		SREG = oldSREG;
	} else {
		uint8_t oldSREG = SREG;
                cli();
		*reg |= bit;
		SREG = oldSREG;
	}
}
```